### PR TITLE
[GEN-567] Add recipients

### DIFF
--- a/config-wrapper.yaml
+++ b/config-wrapper.yaml
@@ -60,3 +60,15 @@ contacts:
   - xindi.guo
   - thomas.yu
   - chelsea.nayan
+  DUKE:
+  - thomas.yu
+  - xindi.guo
+  - chelsea.nayan
+  PROV:
+  - thomas.yu
+  - xindi.guo
+  - chelsea.nayan
+  UCSF:
+  - thomas.yu
+  - xindi.guo
+  - chelsea.nayan


### PR DESCRIPTION
Without this, `genie-bpc-quac.R` will fail with this error:

```

      23:14:48: sending notification for NSCLC2-DUKE reports...
Downloading  [####################]100.00%   42.0bytes/42.0bytes (126.0kB/s) nsclc2_duke_masking_error.csv Done...    Error in value[[3L]](cond) : 400 Client Error: 
recipients must be set.
```