### PR TITLE
[GEN-2636] Remove users from DFCI notification list

### DIFF
--- a/config-wrapper.yaml
+++ b/config-wrapper.yaml
@@ -37,10 +37,7 @@ contacts:
   - thomas.yu
   - chelsea.nayan
   - alyssa.acebedo
-  - karimfarhat
-  - ddand
   - daniel_quinn
-  - myp74
   - ldroby
   MSK:
   - xindi.guo


### PR DESCRIPTION
Removed users 'karimfarhat', 'ddand', and 'myp74' from the config.